### PR TITLE
Add link to sticky header example to navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
                         <li><a href="extensions/fixed-columns.html">Fixed Columns</a></li>
                         <li><a href="extensions/select2-filter.html">Select2 Filter</a></li>
                         <li><a href="extensions/i18n-enhance.html">i18n Enhance</a></li>
+                        <li><a href="extensions/sticky-header.html">Sticky Header</a></li>
                     </ul>
                 </li>
                 <li>

--- a/index.html.conf
+++ b/index.html.conf
@@ -109,6 +109,7 @@
                         <li><a href="extensions/fixed-columns.html">Fixed Columns</a></li>
                         <li><a href="extensions/select2-filter.html">Select2 Filter</a></li>
                         <li><a href="extensions/i18n-enhance.html">i18n Enhance</a></li>
+                        <li><a href="extensions/sticky-header.html">Sticky Header</a></li>
                     </ul>
                 </li>
                 <li>


### PR DESCRIPTION
The example itself does exist(and works), but for some reason the link to it is missing