### PR TITLE
fix:添加font-awesome css 解决detalView不显示icon的问题

### DIFF
--- a/vue-starter/public/index.html
+++ b/vue-starter/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>logo.png">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <title>vue-starter</title>
   </head>
   <body>


### PR DESCRIPTION
添加上这个样式，detailView中的 ➕ 号就能正常显示了 。也能响应点击事件了