### PR TITLE
bugfix:解决cardView下formatter导致的dom树结构错误问题

### DIFF
--- a/vue-starter/src/mixins/table.js
+++ b/vue-starter/src/mixins/table.js
@@ -15,7 +15,7 @@ export default {
         name: key,
         ...obj
       })
-      return `<div class="${key}"/>`
+      return `<div class="${key}"></div>`
     },
 
     vueFormatterPostBody () {


### PR DESCRIPTION
debug发现,bootstrap-table.js 中initRow出来的html还是符合预期的
但是在1461 行 trFragments.append(tr) 以后出来的html树结构不符合预期
后来发现在vueFormatter中返回<div>...</div>就好了