### PR TITLE
Update sticky-header.html

### DIFF
--- a/extensions/sticky-header.html
+++ b/extensions/sticky-header.html
@@ -23,13 +23,13 @@
   <div class="radio">
     <label>
       <input type="radio" name="theadClasses">
-      <code>thead-light</code>
+      <code>table-light</code>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" name="theadClasses">
-      <code>thead-dark</code>
+      <code>table-dark</code>
     </label>
   </div>
 </div>


### PR DESCRIPTION
Previously , `thead-dark` was causing the table header to turn entirely black without the text changing to a light color. 
Here's the screenshot of the problem:
![image](https://github.com/wenzhixin/bootstrap-table-examples/assets/87000253/640bf032-07f8-4a02-b3fc-f872e3e2bf36)
Link to the current example:https://live.bootstrap-table.com/example/extensions/sticky-header.html
So, instead of `thead-light` and `thead-dark` ,` table-light` and` table-dark `could be used to solve the issue
Screenshot of the updated file example:
![image](https://github.com/wenzhixin/bootstrap-table-examples/assets/87000253/3c1593fb-5b00-40b4-8ead-a33204ca0c5d)
Link to the updated example: https://live.bootstrap-table.com/code/c-viswanath/15668
