### PR TITLE
Improve: Englishize treegrid example and add detailed comments

### DIFF
--- a/extensions/treegrid.html
+++ b/extensions/treegrid.html
@@ -24,6 +24,7 @@ init({
   function mounted () {
     $table.bootstrapTable({
       url: 'json/treegrid.json',
+      // idField: The field that uniquely identifies each row
       idField: 'id',
       showColumns: true,
       columns: [
@@ -33,27 +34,31 @@ init({
         },
         {
           field: 'name',
-          title: '名称'
+          // The field value used for the tree display; must match the 'treeShowField' option below
+          title: 'Name'
         },
         {
           field: 'status',
-          title: '状态',
+          title: 'Status',
           sortable: true,
           align: 'center',
           formatter: 'statusFormatter'
         },
         {
           field: 'permissionValue',
-          title: '权限值'
+          title: 'Permission Value'
         }
       ],
+      // treeShowField: Specify the field whose text is shown for tree nodes (required by the treegrid extension)
       treeShowField: 'name',
+      // parentIdField: The field that contains the parent node id
       parentIdField: 'pid',
       onPostBody () {
         const columns = $table.bootstrapTable('getOptions').columns
 
         if (columns && columns[0][1].visible) {
           $table.treegrid({
+            // treeColumn: The zero-based index of the column to show the tree
             treeColumn: 1,
             onChange () {
               $table.bootstrapTable('resetView')
@@ -64,23 +69,10 @@ init({
     })
   }
 
-  window.typeFormatter = value => {
-    if (value === 'menu') {
-      return '菜单'
-    }
-    if (value === 'button') {
-      return '按钮'
-    }
-    if (value === 'api') {
-      return '接口'
-    }
-    return '-'
-  }
-
   window.statusFormatter = value => {
     if (value === 1) {
-      return '<span class="label label-success">正常</span>'
+      return '<span class="label label-success">Active</span>'
     }
-    return '<span class="label label-default">锁定</span>'
+    return '<span class="label label-default">Inactive</span>'
   }
 </script>

--- a/json/treegrid.json
+++ b/json/treegrid.json
@@ -3,63 +3,63 @@
       "id": 1,
       "pid": 0,
       "status": 1,
-      "name": "系统管理",
+      "name": "System Management",
       "permissionValue": "open:system:get"
     },
     {
       "id": 2,
       "pid": 0,
       "status": 1,
-      "name": "字典管理",
+      "name": "Dictionary Management",
       "permissionValue": "open:dict:get"
     },
     {
       "id": 20,
       "pid": 1,
       "status": 1,
-      "name": "新增系统",
+      "name": "Add System",
       "permissionValue": "open:system:add"
     },
     {
       "id": 21,
       "pid": 1,
       "status": 1,
-      "name": "编辑系统",
+      "name": "Edit System",
       "permissionValue": "open:system:edit"
     },
     {
       "id": 22,
       "pid": 1,
       "status": 1,
-      "name": "删除系统",
+      "name": "Delete System",
       "permissionValue": "open:system:delete"
     },
     {
       "id": 33,
       "pid": 2,
       "status": 1,
-      "name": "系统环境",
+      "name": "System Environment",
       "permissionValue": "open:env:get"
     },
     {
       "id": 333,
       "pid": 33,
       "status": 1,
-      "name": "新增环境",
+      "name": "Add Environment",
       "permissionValue": "open:env:add"
     },
     {
       "id": 3333,
       "pid": 33,
       "status": 1,
-      "name": "编辑环境",
+      "name": "Edit Environment",
       "permissionValue": "open:env:edit"
     },
     {
       "id": 233332,
       "pid": 33,
       "status": 0,
-      "name": "删除环境",
+      "name": "Delete Environment",
       "permissionValue": "open:env:delete"
     }
 ]


### PR DESCRIPTION
## Summary
- Translate all Chinese text to English in the treegrid example
- Add inline comments explaining key configuration options (idField, treeShowField, parentIdField, treeColumn)
- Remove unused typeFormatter function
- Update treegrid.json data to English

## Related Issue
Fixes #414

## Test plan
- [x] View the treegrid example page
- [x] Verify all text is in English
- [x] Verify tree structure works correctly
- [x] Verify comments explain the configuration clearly