### PR TITLE
Fix: detail view formatter to display column titles instead of field names

### DIFF
--- a/options/detail-view.html
+++ b/options/detail-view.html
@@ -38,9 +38,14 @@ init({
     const html = []
     const columns = $('#table').bootstrapTable('getOptions').columns
     const getTitle = key => {
-      const column = columns[0].find(column => column.field === key)
+      if (!Array.isArray(columns) || columns.length === 0) {
+        return key
+      }
 
-      return column ? column.title : key
+      const flatColumns = columns.flatMap(row => Array.isArray(row) ? row : [])
+      const column = flatColumns.find(col => col && col.field === key)
+
+      return column && column.title ? column.title : key
     }
 
     for (const [key, value] of Object.entries(row)) {

--- a/options/detail-view.html
+++ b/options/detail-view.html
@@ -36,9 +36,15 @@ init({
 <script>
   window.detailFormatter = (index, row) => {
     const html = []
+    const columns = $('#table').bootstrapTable('getOptions').columns
+    const getTitle = key => {
+      const column = columns[0].find(column => column.field === key)
+
+      return column ? column.title : key
+    }
 
     for (const [key, value] of Object.entries(row)) {
-      html.push(`<p><b>${key}:</b> ${value}</p>`)
+      html.push(`<p><b>${getTitle(key)}:</b> ${value}</p>`)
     }
     return html.join('')
   }


### PR DESCRIPTION
Fixes #319

## Summary
- Update detail view formatter to display human-readable column titles instead of raw field names
- Add safe handling for fields that don't have a corresponding column definition

## Changes
- Modified detailFormatter in options/detail-view.html to lookup column titles from the table configuration
- Added getTitle helper function that safely returns the column title or falls back to the field name

## Test plan
- Verified detail view displays ID, Item Name, Item Price instead of id, name, price
- Verified no errors when row contains fields not in column definition (e.g., amount)