### PR TITLE
Fix vue component test by pinning bootstrap-table version to 1.27.0

### DIFF
--- a/welcomes/vue-component.html
+++ b/welcomes/vue-component.html
@@ -8,7 +8,7 @@ init({
   scripts: [
     'https://unpkg.com/vue@3/dist/vue.global.js',
     'bootstrap-table.min.js',
-    'https://cdn.jsdelivr.net/npm/bootstrap-table@1.27.1/dist/bootstrap-table-vue.umd.js'
+    'https://cdn.jsdelivr.net/npm/bootstrap-table@1.27.0/dist/bootstrap-table-vue.umd.js'
   ]
 })
 </script>


### PR DESCRIPTION
## Description

Pin `bootstrap-table-vue.umd.js` CDN version to `1.27.0` in `vue-component.html` to fix test failures.

## Changes

- `welcomes/vue-component.html`: Change `bootstrap-table@1.27.1` → `bootstrap-table@1.27.0`