### PR TITLE
Fix no-unused-vars lint error in print-printIgnore.html

### DIFF
--- a/for-tests/extensions/print/print-printIgnore.html
+++ b/for-tests/extensions/print/print-printIgnore.html
@@ -36,5 +36,5 @@
     })
   }
 
-  window.totalFormatter = data => 'Total'
+  window.totalFormatter = () => 'Total'
 </script>


### PR DESCRIPTION
Change `data => 'Total'` to `() => 'Total'` to fix ESLint no-unused-vars error.