### PR TITLE
Fix print extension lint errors and add row/cell styles

### DIFF
--- a/extensions/print.html
+++ b/extensions/print.html
@@ -27,7 +27,11 @@ init({
         <th data-field="name">
           Item Name
         </th>
-        <th data-field="price" data-footer-formatter="priceFormatter">
+        <th
+          data-field="price"
+          data-footer-formatter="priceFormatter"
+          data-cell-style="priceStyle"
+        >
           <i class="fa fa-print"></i> Item Price
         </th>
       </tr>
@@ -40,9 +44,33 @@ init({
 
   function mounted () {
     $table.bootstrapTable({
-      printStyles: ['https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css']
+      printStyles: ['https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css'],
+      rowStyle (row, index) {
+        return {
+          css: index % 2 === 0 ? { 'font-weight': 'bold' } : {}
+        }
+      }
     })
   }
 
   window.priceFormatter = data => `$${data.reduce((sum, item) => sum + parseFloat(item.price.replace('$', '')), 0)}`
+
+  window.priceStyle = function (value) {
+    const price = parseFloat(value.replace('$', ''))
+
+    if (price >= 15) {
+      return {
+        css: { 'background-color': '#d4edda', color: '#155724', 'font-weight': 'bold' }
+      }
+    }
+    if (price >= 7) {
+      return {
+        css: { 'background-color': '#fff3cd', color: '#856404', 'font-weight': 'bold' }
+      }
+    }
+    return {
+      css: { 'background-color': '#f8d7da', color: '#721c24', 'font-weight': 'bold' }
+    }
+  }
 </script>
+

--- a/options/buttons-order.html
+++ b/options/buttons-order.html
@@ -15,11 +15,21 @@ init({
 
 <template>
   <ul id="sortable">
-    <li data-value="fullscreen">fullscreen</li>
-    <li data-value="paginationSwitch">paginationSwitch</li>
-    <li data-value="refresh">refresh</li>
-    <li data-value="toggle">toggle</li>
-    <li data-value="columns">columns</li>
+    <li data-value="fullscreen">
+      fullscreen
+    </li>
+    <li data-value="paginationSwitch">
+      paginationSwitch
+    </li>
+    <li data-value="refresh">
+      refresh
+    </li>
+    <li data-value="toggle">
+      toggle
+    </li>
+    <li data-value="columns">
+      columns
+    </li>
   </ul>
 
   <table


### PR DESCRIPTION
## Summary

- Fix no-unused-vars lint error in `print-printIgnore.html` (`data => 'Total'` → `() => 'Total'`)
- Add `rowStyle` and `priceStyle` (cell style) to `print.html` example to demonstrate row and cell styling in print
- Fix vue/max-attributes-per-line warnings in `print.html`
- Fix vue/singleline-html-element-content-newline warnings in `buttons-order.html`

## Test plan

- [x] `npm run lint` passes with 0 errors and 0 warnings
- [x] Verify print.html renders with row alternating bold style and price cell color coding
- [x] Verify buttons-order.html displays correctly