### PR TITLE
Add RTL support example

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -174,6 +174,7 @@ const menus = [
       { label: 'Response Handler', href: '#options/response-handler.html' },
       { label: 'Row Attributes', href: '#options/row-attributes.html', show: ['', 'bootstrap3', 'bootstrap4'] },
       { label: 'Row Style', href: '#options/row-style.html' },
+      { label: 'RTL', href: '#options/rtl.html' },
       { label: 'Search', href: '#options/table-search.html' },
       { label: 'Searchable', href: '#options/searchable.html' },
       { label: 'Search Accent Neutralise', href: '#options/search-accent-neutralise.html' },

--- a/options/rtl.html
+++ b/options/rtl.html
@@ -1,0 +1,43 @@
+<script>
+init({
+  title: 'RTL Support',
+  desc: 'Use the `rtl` option to render the table right-to-left. ' +
+    'Here `rtl: true` mirrors the toolbar, pagination, search box and ' +
+    'sort icons, and the checkbox / index columns move to the right side ' +
+    'natively via `dir="rtl"`. Column alignment keeps its physical meaning ' +
+    'and is not flipped.',
+  links: ['bootstrap-table.min.css'],
+  scripts: ['bootstrap-table.min.js']
+})
+</script>
+
+<template>
+  <table
+    id="table"
+    data-toggle="table"
+    data-rtl="true"
+    data-height="460"
+    data-search="true"
+    data-show-columns="true"
+    data-sort-name="id"
+    data-pagination="true"
+    data-url="json/data1.json"
+  >
+    <thead>
+      <tr>
+        <th data-field="state" data-checkbox="true">
+          Checkbox
+        </th>
+        <th data-field="id" data-sortable="true">
+          ID
+        </th>
+        <th data-field="name" data-sortable="true">
+          Item Name
+        </th>
+        <th data-field="price" data-sortable="true">
+          Item Price
+        </th>
+      </tr>
+    </thead>
+  </table>
+</template>


### PR DESCRIPTION
Add a new example demonstrating the `rtl` option, which renders the table right-to-left.\n\n- Add `options/rtl.html` showing `data-rtl="true"` with search, columns toggle, pagination, and checkbox column\n- Register the "RTL" entry in the options menu (`assets/js/config.js`)